### PR TITLE
Implement a JSTN generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 [![Build Status](https://travis-ci.org/tylerchr/jstn-js.svg?branch=master)](https://travis-ci.org/tylerchr/jstn-js) [![Coverage Status](https://coveralls.io/repos/github/tylerchr/jstn-js/badge.svg)](https://coveralls.io/github/tylerchr/jstn-js)
 
-Implements a JSTN parser and validator in native javascript.
+Implements a JSTN parser, validator, and generator in native javascript.
 
 Details to come.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "jstn",
-  "version": "0.3.0",
-  "description": "a javascript parser and validator for jstn",
+  "version": "0.4.0",
+  "description": "a javascript parser, validator, and generator for jstn",
   "main": "dist/lib/index.js",
   "module": "dist/es/index.js",
   "unpkg": "dist/umd/jstn-js.min.js",

--- a/src/generator.js
+++ b/src/generator.js
@@ -1,0 +1,82 @@
+import { Kinds } from './type.js';
+
+class Generator {
+
+	constructor(pretty, indentation = "  ") {
+		this.pretty = pretty;
+		this.indentation = typeof indentation === 'string' ? indentation : "  ";
+	}
+
+	generate(type, depth) {
+
+		var output = "";
+
+		const writePretty = (s) => {
+			if (this.pretty && Object.keys(type.Properties).length > 0) {
+				output += s;
+			}
+		}
+
+		switch (type.Kind) {
+			case Kinds.String:
+				output += "string"
+				break;
+			case Kinds.Number:
+				output += "number"
+				break;
+			case Kinds.Boolean:
+				output += "boolean"
+				break;
+			case Kinds.Null:
+				output += "null"
+				break;
+			case Kinds.Object:
+				output += "{";
+				writePretty("\n");
+				Object.keys(type.Properties).forEach((propertyName, i, all) => {
+					writePretty(this.indentation.repeat(depth + 1));
+
+					// token: name
+					output += propertyName;
+
+					// token: name-separator
+					output += ":";
+					writePretty(" ");
+
+					// token: member
+					output += this.generate(type.Properties[propertyName], depth + 1);
+
+					// token: delimiter
+					writePretty("\n");
+					if (!this.pretty && i < all.length - 1) {
+						output += ";";
+					}
+				});
+				writePretty(this.indentation.repeat(depth));
+				output += "}";
+				break;
+			case Kinds.Array:
+				output += "[";
+				if (type.Items !== undefined) {
+					output += this.generate(type.Items, depth);
+				}
+				output += "]";
+				break;
+			default:
+				console.warn("got unrecognized kind: " + type.Kind);
+		}
+
+		if (type.Optional === true) {
+			output = output + "?";
+		}
+
+		return output;
+
+	}
+
+}
+
+export default function generate(type, pretty = false) {
+	let g = new Generator(pretty);
+	return g.generate(type, 0);
+}

--- a/src/generator.test.js
+++ b/src/generator.test.js
@@ -1,0 +1,114 @@
+import generate from './generator.js';
+import Types from './type.js';
+
+describe("generator", () => {
+
+	test('renders strings', () => {
+		let t = new Types.JSTNString();
+		expect(generate(t)).toEqual("string");
+	});
+
+	test('renders optional strings', () => {
+		let t = new Types.JSTNString(true);
+		expect(generate(t)).toEqual("string?");
+	});
+
+	test('renders numbers', () => {
+		let t = new Types.JSTNNumber();
+		expect(generate(t)).toEqual("number");
+	});
+
+	test('renders optional numbers', () => {
+		let t = new Types.JSTNNumber(true);
+		expect(generate(t)).toEqual("number?");
+	});
+
+	test('renders booleans', () => {
+		let t = new Types.JSTNBoolean();
+		expect(generate(t)).toEqual("boolean");
+	});
+
+	test('renders optional booleans', () => {
+		let t = new Types.JSTNBoolean(true);
+		expect(generate(t)).toEqual("boolean?");
+	});
+
+	test('renders nulls', () => {
+		let t = new Types.JSTNNull();
+		expect(generate(t)).toEqual("null");
+	});
+
+	test('renders optional nulls', () => {
+		let t = new Types.JSTNNull(true);
+		expect(generate(t)).toEqual("null?");
+	});
+
+	test('renders objects', () => {
+		let t = new Types.JSTNObject();
+		expect(generate(t)).toEqual("{}");
+	});
+
+	test('renders optional objects', () => {
+		let t = new Types.JSTNObject(undefined, true);
+		expect(generate(t)).toEqual("{}?");
+	});
+
+	test('renders objects with properties', () => {
+		let t = new Types.JSTNObject({
+			"firstName": new Types.JSTNString(),
+			"age": new Types.JSTNNumber(true),
+		});
+		expect(generate(t)).toEqual("{firstName:string;age:number?}");
+	});
+
+	test('renders pretty objects with properties', () => {
+		let t = new Types.JSTNObject({
+			"firstName": new Types.JSTNString(),
+			"age": new Types.JSTNNumber(true),
+		});
+		expect(generate(t, true)).toEqual(`{
+  firstName: string
+  age: number?
+}`);
+	});
+
+	test('renders pretty objects with nested properties', () => {
+		let t = new Types.JSTNObject({
+			"firstName": new Types.JSTNString(),
+			"age": new Types.JSTNNumber(true),
+			"residences": new Types.JSTNArray(new Types.JSTNObject({
+				"city": new Types.JSTNString(),
+				"country": new Types.JSTNString(true),
+			})),
+		});
+		expect(generate(t, true)).toEqual(`{
+  firstName: string
+  age: number?
+  residences: [{
+    city: string
+    country: string?
+  }]
+}`);
+	});
+
+	test('renders arrays', () => {
+		let t = new Types.JSTNArray();
+		expect(generate(t)).toEqual("[]");
+	});
+
+	test('renders optional arrays', () => {
+		let t = new Types.JSTNArray(undefined, true);
+		expect(generate(t)).toEqual("[]?");
+	});
+
+	test('renders arrays with contents', () => {
+		let t = new Types.JSTNArray(new Types.JSTNString(), true);
+		expect(generate(t)).toEqual("[string]?");
+	});
+
+	test('renders arrays with nested contents', () => {
+		let t = new Types.JSTNArray(new Types.JSTNArray(new Types.JSTNBoolean(true)), true);
+		expect(generate(t)).toEqual("[[boolean?]]?");
+	});
+
+});

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,14 @@
 import Tokenizer from './scanner.js';
 import parse, { Parser } from './parser.js';
 import { isValid } from './validator.js';
+import generate from './generator.js';
 import Types, { Kinds, JSTNType } from './type.js';
 
 export { Parser, Tokenizer, isValid }
 
 export default {
 	parse,
+	generate,
 
 	Kinds: Kinds,
 

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -3,6 +3,7 @@ import jstn, { Parser, Tokenizer, isValid } from './index.js';
 import parse, { Parser as ParserOriginal } from './parser.js';
 import TokenizerOriginal from './scanner.js';
 import { isValid as isValidOriginal } from './validator.js';
+import generate from './generator.js';
 import Types, { JSTNType, Kinds } from './type.js';
 
 describe('default export', () => {
@@ -11,6 +12,13 @@ describe('default export', () => {
 
 		expect(typeof parse).toBe('function');
 		expect(jstn).toHaveProperty('parse', parse);
+
+	});
+
+	test('includes generate function', () => {
+
+		expect(typeof generate).toBe('function');
+		expect(jstn).toHaveProperty('generate', generate);
 
 	});
 

--- a/src/type.js
+++ b/src/type.js
@@ -1,3 +1,5 @@
+import generate from './generator.js';
+
 import {
 	isValidString,
 	isValidNumber,
@@ -30,6 +32,8 @@ class JSTNType {
 			this.Items = items;
 		}
 	}
+
+	toJSON() { return generate(this); }
 
 }
 

--- a/src/type.test.js
+++ b/src/type.test.js
@@ -1,0 +1,28 @@
+import Types from './type.js';
+
+describe('jstn', () => {
+
+	describe('strings', () => {
+
+		test('serialize to json as generated jstn strings', () => {
+			let sample = new Types.JSTNString(true);
+			let serialized = JSON.stringify(sample);
+			expect(serialized).toEqual("\"string?\"");
+		});
+
+	});
+
+	describe('arrays', () => {
+
+		test('serialize to json as generated jstn strings', () => {
+			let sample = new Types.JSTNArray(new Types.JSTNObject({
+				"firstName": new Types.JSTNString(),
+				"age": new Types.JSTNNumber(true),
+			}));
+			let serialized = JSON.stringify(sample);
+			expect(serialized).toEqual("\"[{firstName:string;age:number?}]\"");
+		});
+
+	});
+
+});


### PR DESCRIPTION
This PR adds a generator implementation, patterned off the Go reference implementation and in conformance with the spec.

Additionally, it extends the `JSONType` prototype with a `toJSON` method that produces a serialization of the JSTN type. For example, this equivalences holds:

```js
let t = new JSTNString(true);
JSON.stringify(t) === '"string?"'
```

This makes for much more convenient serialization in e.g. debugging or JSON-based APIs.