### PR TITLE
removed console errors from validator.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jstn",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "a javascript parser, validator, and generator for jstn",
   "main": "dist/lib/index.js",
   "module": "dist/es/index.js",

--- a/src/validator.js
+++ b/src/validator.js
@@ -9,11 +9,11 @@ function isValidString(type, jsValue) {
 		if (type.Optional) {
 			return true;
 		} else {
-			console.error("validation failed: string: got null for required value");
+			// validation failed: string: got null for required value
 			return false;
 		}
 	}
-	console.error("validation failed: string: unexpected type " + typeof(jsValue));
+	// validation failed: string: unexpected type
 	return false;
 }
 
@@ -24,11 +24,11 @@ function isValidNumber(type, jsValue) {
 		if (type.Optional) {
 			return true;
 		} else {
-			console.error("validation failed: number: got null for required value");
+			// validation failed: number: got null for required value
 			return false;
 		}
 	}
-	console.error("validation failed: number: unexpected type " + typeof(jsValue));
+	// validation failed: number: unexpected type
 	return false;
 }
 
@@ -39,11 +39,11 @@ function isValidBoolean(type, jsValue) {
 		if (type.Optional) {
 			return true;
 		} else {
-			console.error("validation failed: boolean: got null for required value");
+			// validation failed: boolean: got null for required value
 			return false;
 		}
 	}
-	console.error("validation failed: boolean: unexpected type " + typeof(jsValue));
+	// validation failed: boolean: unexpected type
 	return false;
 }
 
@@ -54,11 +54,11 @@ function isValidNull(type, jsValue) {
 		if (type.Optional) {
 			return true;
 		} else {
-			console.error("validation failed: null: got null for required value");
+			// validation failed: null: got null for required value
 			return false;
 		}
 	}
-	console.error("validation failed: null: unexpected type " + typeof(jsValue));
+	// validation failed: null: unexpected type
 	return false;
 }
 
@@ -68,11 +68,11 @@ function isValidArray(type, jsValue) {
 		// it's valid if all the children are of the specified child type
 		return jsValue.reduce((accum, child) => {
 			if (!type.Items) {
-				console.error("validation failed: array: array is not empty");
+				// validation failed: array: array is not empty
 				return false;
 			}
 			if (!isValid(type.Items, child)) {
-				console.error("validation failed: array: invalid sub-element");
+				// validation failed: array: invalid sub-element
 				return false;
 			}
 			return accum;
@@ -82,11 +82,11 @@ function isValidArray(type, jsValue) {
 		if (type.Optional) {
 			return true;
 		} else {
-			console.error("validation failed: array: got null for required value");
+			// validation failed: array: got null for required value
 			return false;
 		}
 	}
-	console.error("validation failed: array: unexpected type " + typeof(jsValue));
+	// validation failed: array: unexpected type
 	return false;
 }
 
@@ -104,7 +104,7 @@ function isValidObject(type, jsValue) {
 			if (jsValue.hasOwnProperty(key)) {
 
 				if (!necessaryProps[key]) {
-					console.error("validation failed: object: contains undeclared property");
+					// validation failed: object: contains undeclared property
 					return false;
 				}
 
@@ -112,7 +112,7 @@ function isValidObject(type, jsValue) {
 				delete necessaryProps[key];
 
 				if (!isValid(type.Properties[key], jsValue[key])) {
-					console.error("validation failed: object: invalid sub-element");
+					// validation failed: object: invalid sub-element
 					return false;
 				}
 			}
@@ -121,7 +121,7 @@ function isValidObject(type, jsValue) {
 		// make sure that any not-located properties were optional
 		return Object.keys(necessaryProps).reduce((accum, key) => {
 			if (!type.Properties[key].Optional) {
-				console.error("validation failed: object: missing required property: " + key);
+				// validation failed: object: missing required property
 				return false;
 			}
 			return accum;
@@ -131,11 +131,11 @@ function isValidObject(type, jsValue) {
 		if (type.Optional) {
 			return true;
 		} else {
-			console.error("validation failed: object: got null for required value");
+			// validation failed: object: got null for required value
 			return false;
 		}
 	}
-	console.error("validation failed: object: unexpected type " + typeof(jsValue));
+	// validation failed: object: unexpected type
 	return false;
 }
 


### PR DESCRIPTION
<img width="413" alt="Screen Shot 2021-03-04 at 1 43 08 PM" src="https://user-images.githubusercontent.com/46510750/110027733-91cb9b80-7cef-11eb-8e75-3ce14df7d46f.png">
We end up with a lot of these in a service consuming this repo. It would be great to remove these required console logs. If desired, we could think about some kind of dev-mode flag to surface these errors during development.  